### PR TITLE
Updated data processor to handle Type Errors when importing incidents and improved name matching

### DIFF
--- a/functions/utils/DataProcessor.js
+++ b/functions/utils/DataProcessor.js
@@ -101,6 +101,12 @@ class DataProcessor {
         let routeFilter = this.filters["routes"];
         // iterate through all current incidents and filter down to incidentRoutes
         for(let incident of incidents){
+            //Catche TypeError: Cannot read properties of null (or undefined) 
+            if (!incident.properties.routeName) {
+                console.warn("Skipping incident with undefined routeName:", incident);
+                continue;
+            } 
+
             // extract info from the incident
             let incidentRoute = incident['properties']['routeName'].toUpperCase();
 
@@ -115,10 +121,11 @@ class DataProcessor {
                     }
                 }
             }
-
+            
+            let baseIncidentRoute = incidentRoute.slice(0, -1);
             // check all routeFilter routes against the current incidentRoute
             for(let route in routeFilter){
-                if(incidentRoute.indexOf(route) !== -1){
+                if(baseIncidentRoute === route){
                     if(!this.hasRoute(route)){
                         this.routes[route] = new Route(route)
                     }


### PR DESCRIPTION
1. Notice the app break with server errors when importing incidents without a routeName, added condition to catch incidents without a routeName and continue. Might need to adjust `Incident.js` to add those to a new property. IIRC, the incident message was contained text such as EMERGENCY alert or GLOBAL alert. 
2. Stumbled on a bug where CO-90E was being imported as a CO-9 incident. Created `baseIncidentRoute` variable to remove the last character from incoming data then perform an exact match to route filter. 